### PR TITLE
Potential fix for code scanning alert no. 9: Uncontrolled data used in path expression

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -259,7 +259,10 @@ def process_pdfs():
 @app.route('/api/export/<result_id>', methods=['GET'])
 def export_results(result_id):
     try:
-        result_file = os.path.join(RESULTS_FOLDER, f'{result_id}.json')
+        result_file = os.path.normpath(os.path.join(RESULTS_FOLDER, f'{result_id}.json'))
+        
+        if not result_file.startswith(RESULTS_FOLDER):
+            return jsonify({'error': 'Invalid result ID'}), 400
         
         if not os.path.exists(result_file):
             return jsonify({'error': 'Results not found'}), 404


### PR DESCRIPTION
Potential fix for [https://github.com/imranshariffhs/Document-Process/security/code-scanning/9](https://github.com/imranshariffhs/Document-Process/security/code-scanning/9)

To fix the issue, we need to ensure that the constructed file path is safe and does not allow directory traversal or access to unintended files. This can be achieved by normalizing the path using `os.path.normpath` and verifying that the resulting path is within the `RESULTS_FOLDER`. If the normalized path does not start with `RESULTS_FOLDER`, the request should be rejected.

Steps to implement the fix:
1. Use `os.path.normpath` to normalize the constructed file path.
2. Check if the normalized path starts with the `RESULTS_FOLDER` using `startswith`.
3. If the check fails, return an error response indicating that the request is not allowed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
