### PR TITLE
Potential fix for code scanning alert no. 18: Information exposure through an exception

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -221,9 +221,9 @@ def process_pdfs():
             return jsonify({'error': 'PDF processing failed'}), 500
             
         if result.get('status') == 'error':
+            print(f"Error during PDF processing: {result.get('error', 'Unknown error')}")
             return jsonify({
-                'error': result.get('error', 'Unknown error during processing'),
-                'details': result
+                'error': 'An error occurred during PDF processing. Please try again later.'
             }), 500
             
         filename = os.path.basename(result['file_path']).replace(f'{session_id}_', '')
@@ -268,8 +268,7 @@ def process_pdfs():
     except Exception as e:
         print(f"Error in process_pdfs: {str(e)}")
         return jsonify({
-            'error': 'Internal server error',
-            'details': str(e)
+            'error': 'An internal error has occurred. Please contact support if the issue persists.'
         }), 500
 
 @app.route('/api/export/<result_id>', methods=['GET'])

--- a/backend/pdf_process.py
+++ b/backend/pdf_process.py
@@ -205,7 +205,7 @@ def process_single_pdf(file_path, field_definitions):
                 'status': 'error',
                 'data': {field.get('name', ''): None for field in field_definitions},
                 'file_path': file_path,
-                'error': f'Error reading PDF text file: {str(e)}'
+                'error': 'An error occurred while reading the PDF text file.'
             }
 
         # Format field definitions
@@ -229,7 +229,7 @@ def process_single_pdf(file_path, field_definitions):
                 'status': 'error',
                 'data': {field.get('name', ''): None for field in field_definitions},
                 'file_path': file_path,
-                'error': error_msg
+                'error': 'An error occurred while processing the PDF text file.'
             }
         
         # Extract JSON from response


### PR DESCRIPTION
Potential fix for [https://github.com/imranshariffhs/Document-Process/security/code-scanning/18](https://github.com/imranshariffhs/Document-Process/security/code-scanning/18)

To fix the issue, we need to ensure that detailed error information, including stack traces, is not exposed to external users. Instead, we should log the detailed error information internally (e.g., to a file or monitoring system) and return a generic error message to the user. Specifically:

1. Modify the `process_pdfs` function in `backend/app.py` to sanitize the error details before including them in the response.
2. Ensure that the `process_single_pdf` function in `backend/pdf_process.py` does not propagate sensitive error details to the caller.
3. Log detailed error information internally using a logging mechanism.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
