### PR TITLE
Potential fix for code scanning alert no. 16: Information exposure through an exception

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -221,9 +221,9 @@ def process_pdfs():
             return jsonify({'error': 'PDF processing failed'}), 500
             
         if result.get('status') == 'error':
+            app.logger.error(f"Error during processing: {result}")
             return jsonify({
-                'error': result.get('error', 'Unknown error during processing'),
-                'details': result
+                'error': 'An internal error occurred during processing. Please try again later.'
             }), 500
             
         filename = os.path.basename(result['file_path']).replace(f'{session_id}_', '')

--- a/backend/pdf_process.py
+++ b/backend/pdf_process.py
@@ -201,11 +201,12 @@ def process_single_pdf(file_path, field_definitions):
             error_msg = f"Error reading file {output_path}: {str(e)}"
             print(error_msg)
             logger.error(error_msg)
+            logger.error(f"Error reading PDF text file: {str(e)}")
             return {
                 'status': 'error',
                 'data': {field.get('name', ''): None for field in field_definitions},
                 'file_path': file_path,
-                'error': f'Error reading PDF text file: {str(e)}'
+                'error': 'An error occurred while reading the PDF text file.'
             }
 
         # Format field definitions
@@ -225,11 +226,11 @@ def process_single_pdf(file_path, field_definitions):
             error_msg = f"Error getting LLM response: {str(e)}"
             print(error_msg)
             logger.error(error_msg)
+            logger.error(f"Error getting LLM response: {error_msg}")
             return {
                 'status': 'error',
                 'data': {field.get('name', ''): None for field in field_definitions},
-                'file_path': file_path,
-                'error': error_msg
+                'error': 'An error occurred while processing the LLM response.'
             }
         
         # Extract JSON from response


### PR DESCRIPTION
Potential fix for [https://github.com/imranshariffhs/Document-Process/security/code-scanning/16](https://github.com/imranshariffhs/Document-Process/security/code-scanning/16)

To fix the issue, the code should ensure that detailed error messages or stack traces are not exposed to external users. Instead, a generic error message should be returned to the user, while the detailed error information is logged internally for debugging purposes. This involves modifying the `jsonify` response on line 224 of `backend/app.py` to exclude sensitive details and ensuring that the `result` object is sanitized before being sent to the user.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
